### PR TITLE
Add NamerFunc to allow ordinary functions as Namer

### DIFF
--- a/grpcreflect.go
+++ b/grpcreflect.go
@@ -284,6 +284,17 @@ type Namer interface {
 	Names() []string
 }
 
+// The NamerFunc type is an adapter to allow the use of ordinary functions as Namer,
+// it's useful when you want to use a function as a Namer but don't want to define a new type.
+// example: reflector := grpcreflect.NewReflector(grpcreflect.NamerFunc(func() []string { return s.names }))
+type NamerFunc func() []string
+
+// Names returns the service names, implements the Namer interface.
+func (f NamerFunc) Names() []string {
+	return f()
+}
+
+
 // An Option configures a Reflector.
 type Option interface {
 	apply(*Reflector)

--- a/grpcreflect.go
+++ b/grpcreflect.go
@@ -297,7 +297,6 @@ func (f NamerFunc) Names() []string {
 	return f()
 }
 
-
 // An Option configures a Reflector.
 type Option interface {
 	apply(*Reflector)

--- a/grpcreflect.go
+++ b/grpcreflect.go
@@ -284,9 +284,12 @@ type Namer interface {
 	Names() []string
 }
 
-// The NamerFunc type is an adapter to allow the use of ordinary functions as Namer,
-// it's useful when you want to use a function as a Namer but don't want to define a new type.
-// example: reflector := grpcreflect.NewReflector(grpcreflect.NamerFunc(func() []string { return s.names }))
+// NamerFunc is an adapter to allow the use of an ordinary function as a Namer.
+// Example:
+//
+//	reflector := grpcreflect.NewReflector(grpcreflect.NamerFunc(
+//		func() []string { return s.names },
+//	))
 type NamerFunc func() []string
 
 // Names returns the service names, implements the Namer interface.


### PR DESCRIPTION
Added a type `NamerFunc`, it's an adapter to allow the use of ordinary functions as `Namer`, it's useful when you want to use a function as a `Namer` but don't want to define a new type.
``` go
// example.go
reflector := grpcreflect.NewReflector(NamerFunc(func() []string {
    return s.svcs
}))
s.mux.Handle(grpcreflect.NewHandlerV1(reflector))
s.mux.Handle(grpcreflect.NewHandlerV1Alpha(reflector))
```