### PR TITLE
Don't send placeholder files; improve caching of sent files

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -1,2 +1,3 @@
-connectrpc.com/grpchealth v1.2.0/go.mod h1:fZos12C4p/ZaZC6OwBGZUM+i/fhnRhv75ax/6V/zIeM=
 connectrpc.com/grpcreflect v1.1.0/go.mod h1:QBX/Lf8oW35iCFCBYlPVTM5xrlKG1dMC+55klHv7YvE=
+github.com/golang/protobuf v1.5.0 h1:LUVKkCeviFUMKqHa4tXIIij/lbhnMbP7Fn5wKdKkRh4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/grpcreflect.go
+++ b/grpcreflect.go
@@ -317,15 +317,15 @@ type fileDescriptorNameSet struct {
 	names map[string]struct{}
 }
 
-func (s *fileDescriptorNameSet) Insert(path string) {
+func (s *fileDescriptorNameSet) Insert(fd protoreflect.FileDescriptor) {
 	if s.names == nil {
 		s.names = make(map[string]struct{}, 1)
 	}
-	s.names[path] = struct{}{}
+	s.names[fd.Path()] = struct{}{}
 }
 
-func (s *fileDescriptorNameSet) Contains(path string) bool {
-	_, ok := s.names[path]
+func (s *fileDescriptorNameSet) Contains(fd protoreflect.FileDescriptor) bool {
+	_, ok := s.names[fd.Path()]
 	return ok
 }
 
@@ -343,10 +343,10 @@ func fileDescriptorWithDependencies(rootFile protoreflect.FileDescriptor, sent *
 		if curr.IsPlaceholder() {
 			continue // don't bother serializing placeholders
 		}
-		if len(results) == 0 || !sent.Contains(curr.Path()) { // always send root fd
+		if len(results) == 0 || !sent.Contains(curr) { // always send root fd
 			// Mark as sent immediately. If we hit an error marshaling below, there's
 			// no point trying again later.
-			sent.Insert(curr.Path())
+			sent.Insert(curr)
 			encoded, err := proto.Marshal(protodesc.ToFileDescriptorProto(curr))
 			if err != nil {
 				return nil, err

--- a/grpcreflect.go
+++ b/grpcreflect.go
@@ -314,18 +314,18 @@ type ExtensionResolver interface {
 }
 
 type fileDescriptorNameSet struct {
-	names map[protoreflect.FullName]struct{}
+	names map[string]struct{}
 }
 
-func (s *fileDescriptorNameSet) Insert(fd protoreflect.FileDescriptor) {
+func (s *fileDescriptorNameSet) Insert(path string) {
 	if s.names == nil {
-		s.names = make(map[protoreflect.FullName]struct{}, 1)
+		s.names = make(map[string]struct{}, 1)
 	}
-	s.names[fd.FullName()] = struct{}{}
+	s.names[path] = struct{}{}
 }
 
-func (s *fileDescriptorNameSet) Contains(fd protoreflect.FileDescriptor) bool {
-	_, ok := s.names[fd.FullName()]
+func (s *fileDescriptorNameSet) Contains(path string) bool {
+	_, ok := s.names[path]
 	return ok
 }
 
@@ -343,10 +343,10 @@ func fileDescriptorWithDependencies(rootFile protoreflect.FileDescriptor, sent *
 		if curr.IsPlaceholder() {
 			continue // don't bother serializing placeholders
 		}
-		if len(results) == 0 || !sent.Contains(curr) { // always send root fd
+		if len(results) == 0 || !sent.Contains(curr.Path()) { // always send root fd
 			// Mark as sent immediately. If we hit an error marshaling below, there's
 			// no point trying again later.
-			sent.Insert(curr)
+			sent.Insert(curr.Path())
 			encoded, err := proto.Marshal(protodesc.ToFileDescriptorProto(curr))
 			if err != nil {
 				return nil, err

--- a/grpcreflect_test.go
+++ b/grpcreflect_test.go
@@ -438,7 +438,7 @@ func TestFileDescriptorWithDependencies(t *testing.T) {
 
 			sent := &fileDescriptorNameSet{}
 			for _, path := range testCase.sent {
-				sent.Insert(path)
+				sent.Insert(dummyFile{path: path})
 			}
 
 			descriptors, err := fileDescriptorWithDependencies(testCase.root, sent)
@@ -485,4 +485,13 @@ type placeholderFile struct {
 
 func (placeholderFile) IsPlaceholder() bool {
 	return true
+}
+
+type dummyFile struct {
+	protoreflect.FileDescriptor
+	path string
+}
+
+func (f dummyFile) Path() string {
+	return f.path
 }

--- a/grpcreflect_test.go
+++ b/grpcreflect_test.go
@@ -19,14 +19,20 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
+	"sort"
 	"testing"
 
 	"connectrpc.com/connect"
 	_ "connectrpc.com/grpcreflect/internal/gen/go/connect/reflecttest/v1"
 	reflectionv1 "connectrpc.com/grpcreflect/internal/gen/go/connectext/grpc/reflection/v1"
 	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/descriptorpb"
 )
 
 const actualServiceName = "connectext.grpc.reflection.v1.ServerReflection"
@@ -294,4 +300,189 @@ func testReflector(t *testing.T, reflector *Reflector, servicePath string) {
 		}
 		assertFileDescriptorResponseNotFound(t, req)
 	})
+}
+
+func TestFileDescriptorWithDependencies(t *testing.T) {
+	t.Parallel()
+
+	depFile, err := protodesc.NewFile(
+		&descriptorpb.FileDescriptorProto{
+			Name: proto.String("dep.proto"),
+		}, nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	deps := &protoregistry.Files{}
+	if err := deps.RegisterFile(depFile); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	rootFileProto := &descriptorpb.FileDescriptorProto{
+		Name: proto.String("root.proto"),
+		Dependency: []string{
+			"google/protobuf/descriptor.proto",
+			"connect/reflecttest/v1/reflecttest_ext.proto",
+			"dep.proto",
+		},
+	}
+
+	// dep.proto is in deps; the other imports come from protoregistry.GlobalFiles
+	resolver := &combinedResolver{first: protoregistry.GlobalFiles, second: deps}
+	rootFile, err := protodesc.NewFile(rootFileProto, resolver)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	// Create a file hierarchy that contains a placeholder for dep.proto
+	placeholderDep := placeholderFile{depFile}
+	placeholderDeps := &protoregistry.Files{}
+	if err := placeholderDeps.RegisterFile(placeholderDep); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	resolver = &combinedResolver{first: protoregistry.GlobalFiles, second: placeholderDeps}
+
+	rootFileHasPlaceholderDep, err := protodesc.NewFile(rootFileProto, resolver)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	rootFileIsPlaceholder := placeholderFile{rootFile}
+
+	// Full transitive dependency graph of root.proto includes five files:
+	// - root.proto
+	//   - google/protobuf/descriptor.proto
+	//   - connect/reflecttest/v1/reflecttest_ext.proto
+	//     - connect/reflecttest/v1/reflecttest.proto
+	//   - dep.proto
+
+	testCases := []struct {
+		name   string
+		sent   []string
+		root   protoreflect.FileDescriptor
+		expect []string
+	}{
+		{
+			name: "send_all",
+			root: rootFile,
+			// expect full transitive closure
+			expect: []string{
+				"root.proto",
+				"google/protobuf/descriptor.proto",
+				"connect/reflecttest/v1/reflecttest_ext.proto",
+				"connect/reflecttest/v1/reflecttest.proto",
+				"dep.proto",
+			},
+		},
+		{
+			name: "already_sent",
+			sent: []string{
+				"root.proto",
+				"google/protobuf/descriptor.proto",
+				"connect/reflecttest/v1/reflecttest_ext.proto",
+				"connect/reflecttest/v1/reflecttest.proto",
+				"dep.proto",
+			},
+			root: rootFile,
+			// expect only the root to be re-sent
+			expect: []string{"root.proto"},
+		},
+		{
+			name: "some_already_sent",
+			sent: []string{
+				"connect/reflecttest/v1/reflecttest_ext.proto",
+				"connect/reflecttest/v1/reflecttest.proto",
+			},
+			root: rootFile,
+			expect: []string{
+				"root.proto",
+				"google/protobuf/descriptor.proto",
+				"dep.proto",
+			},
+		},
+		{
+			name: "root_is_placeholder",
+			root: rootFileIsPlaceholder,
+			// expect error, no files
+		},
+		{
+			name: "placeholder_skipped",
+			root: rootFileHasPlaceholderDep,
+			// dep.proto is a placeholder so is skipped
+			expect: []string{
+				"root.proto",
+				"google/protobuf/descriptor.proto",
+				"connect/reflecttest/v1/reflecttest_ext.proto",
+				"connect/reflecttest/v1/reflecttest.proto",
+			},
+		},
+		{
+			name: "placeholder_skipped_and_some_sent",
+			sent: []string{
+				"connect/reflecttest/v1/reflecttest_ext.proto",
+				"connect/reflecttest/v1/reflecttest.proto",
+			},
+			root: rootFileHasPlaceholderDep,
+			expect: []string{
+				"root.proto",
+				"google/protobuf/descriptor.proto",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			sent := &fileDescriptorNameSet{}
+			for _, path := range testCase.sent {
+				sent.Insert(path)
+			}
+
+			descriptors, err := fileDescriptorWithDependencies(testCase.root, sent)
+			if len(testCase.expect) == 0 {
+				// if we're not expecting any files then we're expecting an error
+				if err == nil {
+					t.Fatalf("expecting an error; instead got %d files", len(descriptors))
+				}
+				return
+			}
+
+			checkDescriptorResults(t, descriptors, testCase.expect)
+		})
+	}
+}
+
+func checkDescriptorResults(t *testing.T, descriptors [][]byte, expect []string) {
+	t.Helper()
+	if len(descriptors) != len(expect) {
+		t.Errorf("expected result to contain %d descriptor(s); instead got %d", len(expect), len(descriptors))
+	}
+	names := map[string]struct{}{}
+	for i, desc := range descriptors {
+		var descProto descriptorpb.FileDescriptorProto
+		if err := proto.Unmarshal(desc, &descProto); err != nil {
+			t.Fatalf("could not unmarshal descriptor result #%d", i+1)
+		}
+		names[descProto.GetName()] = struct{}{}
+	}
+	actual := make([]string, 0, len(names))
+	for name := range names {
+		actual = append(actual, name)
+	}
+	sort.Strings(actual)
+	sort.Strings(expect)
+	if !reflect.DeepEqual(actual, expect) {
+		t.Fatalf("expected file descriptors for %v; instead got %v", expect, actual)
+	}
+}
+
+type placeholderFile struct {
+	protoreflect.FileDescriptor
+}
+
+func (placeholderFile) IsPlaceholder() bool {
+	return true
 }


### PR DESCRIPTION
The original motivation for this change was to mirror the fix in https://github.com/grpc/grpc-go/pull/6771. (See that issue for more context; originally reported as a bug against recent version of `grpcurl`.)

The issue there is that "placeholder" files (see [`Descriptor.IsPlaceholder`](https://pkg.go.dev/google.golang.org/protobuf/reflect/protoreflect#Descriptor)) would be serialized as invalid descriptor protos ([related](https://go-review.googlesource.com/c/protobuf/+/540455)). But they really shouldn't be serialized at all: they represent _missing_ dependencies, so it's better to elide them.

While writing new tests for this, I also discovered that we were caching sent files incorrectly. The code was using `FileDescriptor.FullName` which is sadly not really specified in the docs. In practice, this returns the file's _package_, which is not enough to uniquely identify a file. That means we would only send back one dependency per package (instead of the entire graph), and then require the client ask for the others one-at-a-time. So this branch fixes that, too.