### PR TITLE
Upgrade go to v1.22

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,14 +15,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.19.x,1.20.x,1.21.x]
+        go-version: [1.20.x,1.21.x,1.22.x]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
       - name: Test
@@ -30,5 +30,5 @@ jobs:
       - name: Lint
         # Often, lint & gofmt guidelines depend on the Go version. To prevent
         # conflicting guidance, run only on the most recent supported version.
-        if: matrix.go-version == '1.21.x'
+        if: matrix.go-version == '1.22.x'
         run: make checkgenerate && make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,14 +39,16 @@ linters:
     - golint            # deprecated by Go team
     - gomnd             # some unnamed constants are okay
     - ifshort           # deprecated by author
+    - inamedparam       # convention is not followed
     - interfacer        # deprecated by author
     - ireturn           # "accept interfaces, return structs" isn't ironclad
     - lll               # don't want hard limits for line length
     - maintidx          # covered by gocyclo
     - maligned          # readability trumps efficient struct packing
-    - musttag           # buggy in release 1.54.1, fails with mysterious error
     - nlreturn          # generous whitespace violates house style
+    - nonamedreturns    # named returns are fine; it's *bare* returns that are bad
     - nosnakecase       # deprecated in https://github.com/golangci/golangci-lint/pull/3065
+    - protogetter       # too many false positives
     - scopelint         # deprecated by author
     - structcheck       # abandoned
     - testpackage       # internal tests are fine

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ MAKEFLAGS += --no-print-directory
 BIN=$(abspath .tmp/bin)
 export PATH := $(BIN):$(PATH)
 export GOBIN := $(abspath $(BIN))
-COPYRIGHT_YEARS := 2022-2023
+COPYRIGHT_YEARS := 2022-2024
 LICENSE_IGNORE := --ignore /testdata/ --ignore internal/proto/connectext/
 
 .PHONY: help
@@ -71,15 +71,15 @@ checkgenerate:
 
 $(BIN)/buf: Makefile
 	@mkdir -p $(@D)
-	go install github.com/bufbuild/buf/cmd/buf@v1.26.1
+	go install github.com/bufbuild/buf/cmd/buf@v1.29.0
 
 $(BIN)/license-header: Makefile
 	@mkdir -p $(@D)
-	go install github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@v1.26.1
+	go install github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@v1.29.0
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.1
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.2
 
 $(BIN)/protoc-gen-go: Makefile
 	@mkdir -p $(@D)

--- a/client.go
+++ b/client.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The Connect Authors
+// Copyright 2022-2024 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/client_example_test.go
+++ b/client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The Connect Authors
+// Copyright 2022-2024 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/client_test.go
+++ b/client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The Connect Authors
+// Copyright 2022-2024 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module connectrpc.com/grpcreflect
 
-go 1.19
+go 1.20
 
 require (
 	connectrpc.com/connect v1.11.0

--- a/grpcreflect.go
+++ b/grpcreflect.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The Connect Authors
+// Copyright 2022-2024 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/grpcreflect_test.go
+++ b/grpcreflect_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The Connect Authors
+// Copyright 2022-2024 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/gen/go/connect/reflecttest/v1/reflecttest.pb.go
+++ b/internal/gen/go/connect/reflecttest/v1/reflecttest.pb.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The Connect Authors
+// Copyright 2022-2024 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/gen/go/connect/reflecttest/v1/reflecttest_ext.pb.go
+++ b/internal/gen/go/connect/reflecttest/v1/reflecttest_ext.pb.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The Connect Authors
+// Copyright 2022-2024 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/gen/go/connectext/grpc/reflection/v1/reflection.pb.go
+++ b/internal/gen/go/connectext/grpc/reflection/v1/reflection.pb.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The Connect Authors
+// Copyright 2022-2024 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/proto/connect/reflecttest/v1/reflecttest.proto
+++ b/internal/proto/connect/reflecttest/v1/reflecttest.proto
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The Connect Authors
+// Copyright 2022-2024 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/proto/connect/reflecttest/v1/reflecttest_ext.proto
+++ b/internal/proto/connect/reflecttest/v1/reflecttest_ext.proto
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The Connect Authors
+// Copyright 2022-2024 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/resolvertest/resolverhack_test.go
+++ b/internal/resolvertest/resolverhack_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The Connect Authors
+// Copyright 2022-2024 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Increase the min go v1.20 and the current to v1.122. Also bumps the Makefile deps for buf, license and linting.