### PR TITLE
Remove dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
This removes the dependabot configuration to be consistent with other go libraries in the connectrpc org. It also looks like dependabot doesn't work for go workspaces https://github.com/dependabot/dependabot-core/issues/6012. 